### PR TITLE
Add sensitive values to base module for sanitizer testing

### DIFF
--- a/base/main.tf
+++ b/base/main.tf
@@ -131,21 +131,30 @@ variable "unit_secret" {
   default     = "unit-secret-default-updated"
 }
 
+# Everything else in this config is static, so without this the second plan for a unit is all
+# no-op. The visual plan drops no-op resources, which would leave Resource changes view empty.
+# Bump this as a workspace variable to make every unit update in place again.
+variable "revision" {
+  description = "Bump between runs so every unit updates in place and the view has content."
+  type        = string
+  default     = "1"
+}
+
 # Sensitive resource attributes produce after_sensitive marks, which is what makes masked
 # values show up in the per-unit Resource changes view.
 resource "terraform_data" "secrets" {
   input = {
-    public = "visible-${var.module_name}"
-    secret = sensitive("resource-secret-${var.module_name}")
+    public = "visible-${var.module_name}-rev${var.revision}"
+    secret = sensitive("resource-secret-${var.module_name}-rev${var.revision}")
     nested = {
       plain = "visible-nested-${var.module_name}"
-      deep  = { token = sensitive(var.unit_secret) }
+      deep  = { token = sensitive("${var.unit_secret}-rev${var.revision}") }
     }
   }
 }
 
 output "sensitive_output" {
   description = "Must arrive masked in the per-unit sanitized plan."
-  value       = "output-secret-${var.module_name}"
+  value       = "output-secret-${var.module_name}-rev${var.revision}"
   sensitive   = true
 }

--- a/base/main.tf
+++ b/base/main.tf
@@ -112,3 +112,40 @@ output "resource_id" {
   description = "A unique identifier for the resource"
   value = random_string.example[0].result
 }
+
+# ---------------------------------------------------------------------------------------
+# Sensitive values for plan-sanitizer testing (SCALRCORE-37162).
+#
+# Everything below is derived from var.module_name / var.unit_secret, so each Terragrunt unit
+# produces its own distinct masked values and units can be told apart in the sanitized output.
+#
+# Values must be known at plan time to be visible as masked in Resource changes view. That rules
+# out computed attributes such as random_password.result, which are null in the plan and so have
+# nothing to mask. terraform_data with sensitive() keeps the values known. Requires Terraform 1.4+.
+# ---------------------------------------------------------------------------------------
+
+variable "unit_secret" {
+  description = "Sensitive, set per unit so masked values differ between units."
+  type        = string
+  sensitive   = true
+  default     = "unit-secret-default"
+}
+
+# Sensitive resource attributes produce after_sensitive marks, which is what makes masked
+# values show up in the per-unit Resource changes view.
+resource "terraform_data" "secrets" {
+  input = {
+    public = "visible-${var.module_name}"
+    secret = sensitive("resource-secret-${var.module_name}")
+    nested = {
+      plain = "visible-nested-${var.module_name}"
+      deep  = { token = sensitive(var.unit_secret) }
+    }
+  }
+}
+
+output "sensitive_output" {
+  description = "Must arrive masked in the per-unit sanitized plan."
+  value       = "output-secret-${var.module_name}"
+  sensitive   = true
+}

--- a/base/main.tf
+++ b/base/main.tf
@@ -128,7 +128,7 @@ variable "unit_secret" {
   description = "Sensitive, set per unit so masked values differ between units."
   type        = string
   sensitive   = true
-  default     = "unit-secret-default"
+  default     = "unit-secret-default-updated"
 }
 
 # Sensitive resource attributes produce after_sensitive marks, which is what makes masked

--- a/terragrunt-module-longlonglonglonglonglonglong/module-a/terragrunt.hcl
+++ b/terragrunt-module-longlonglonglonglonglonglong/module-a/terragrunt.hcl
@@ -11,5 +11,6 @@ terraform {
 inputs = {
   module_name = "module-a"
   resource_id = "resource-001"
+  unit_secret = "secret-terragrunt-module-longlonglonglonglonglonglong-module-a"
 }
 

--- a/terragrunt-module-longlonglonglonglonglonglong/module-a/terragrunt.hcl
+++ b/terragrunt-module-longlonglonglonglonglonglong/module-a/terragrunt.hcl
@@ -1,4 +1,4 @@
-include {
+include "root" {
   path = find_in_parent_folders("../base/backend.hcl")
 }
 

--- a/terragrunt-module-longlonglonglonglonglonglong/module-b/terragrunt.hcl
+++ b/terragrunt-module-longlonglonglonglonglonglong/module-b/terragrunt.hcl
@@ -1,4 +1,4 @@
-include {
+include "root" {
     path = find_in_parent_folders("base/backend.hcl")
 }
 

--- a/terragrunt-module-longlonglonglonglonglonglong/module-b/terragrunt.hcl
+++ b/terragrunt-module-longlonglonglonglonglonglong/module-b/terragrunt.hcl
@@ -9,4 +9,5 @@ terraform {
 inputs = {
   module_name = "module-b"
   resource_id = "resource-002"
+  unit_secret = "secret-terragrunt-module-longlonglonglonglonglonglong-module-b"
 }

--- a/terragrunt-module-longlonglonglonglonglonglong/module-c/terragrunt.hcl
+++ b/terragrunt-module-longlonglonglonglonglonglong/module-c/terragrunt.hcl
@@ -10,4 +10,5 @@ include {
 inputs = {
   module_name = "module-c"
   resource_id = "resource-003"
+  unit_secret = "secret-terragrunt-module-longlonglonglonglonglonglong-module-c"
 }

--- a/terragrunt-module-longlonglonglonglonglonglong/module-c/terragrunt.hcl
+++ b/terragrunt-module-longlonglonglonglonglonglong/module-c/terragrunt.hcl
@@ -2,7 +2,7 @@ terraform {
   source = "../../base/main.tf"
 }
 
-include {
+include "root" {
   path = find_in_parent_folders("../base/backend.hcl")
 }
 

--- a/terragrunt-module-longlonglonglonglonglonglong/module-d/terragrunt.hcl
+++ b/terragrunt-module-longlonglonglonglonglonglong/module-d/terragrunt.hcl
@@ -11,4 +11,5 @@ include {
 inputs = {
   module_name = "module-d"
   resource_id = "resource-003"
+  unit_secret = "secret-terragrunt-module-longlonglonglonglonglonglong-module-d"
 }

--- a/terragrunt-module-longlonglonglonglonglonglong/module-d/terragrunt.hcl
+++ b/terragrunt-module-longlonglonglonglonglonglong/module-d/terragrunt.hcl
@@ -2,7 +2,7 @@ terraform {
   source = "../../base/main.tf"
 }
 
-include {
+include "root" {
   path = find_in_parent_folders("../base/backend.hcl")
 }
 

--- a/terragrunt-module-longlonglonglonglonglonglong/module-e/terragrunt.hcl
+++ b/terragrunt-module-longlonglonglonglonglonglong/module-e/terragrunt.hcl
@@ -2,7 +2,7 @@ terraform {
   source = "../../base/main.tf"
 }
 
-include {
+include "root" {
   path = find_in_parent_folders("../base/backend.hcl")
 }
 

--- a/terragrunt-module-longlonglonglonglonglonglong/module-e/terragrunt.hcl
+++ b/terragrunt-module-longlonglonglonglonglonglong/module-e/terragrunt.hcl
@@ -11,4 +11,5 @@ include {
 inputs = {
   module_name = "module-e"
   resource_id = "resource-003"
+  unit_secret = "secret-terragrunt-module-longlonglonglonglonglonglong-module-e"
 }

--- a/terragrunt-module1/module-a/terragrunt.hcl
+++ b/terragrunt-module1/module-a/terragrunt.hcl
@@ -11,5 +11,6 @@ terraform {
 inputs = {
   module_name = "module-a"
   resource_id = "resource-001"
+  unit_secret = "secret-terragrunt-module1-module-a"
 }
 

--- a/terragrunt-module1/module-a/terragrunt.hcl
+++ b/terragrunt-module1/module-a/terragrunt.hcl
@@ -1,4 +1,4 @@
-include {
+include "root" {
   path = find_in_parent_folders("../base/backend.hcl")
 }
 

--- a/terragrunt-module1/module-b/terragrunt.hcl
+++ b/terragrunt-module1/module-b/terragrunt.hcl
@@ -1,4 +1,4 @@
-include {
+include "root" {
     path = find_in_parent_folders("base/backend.hcl")
 }
 

--- a/terragrunt-module1/module-b/terragrunt.hcl
+++ b/terragrunt-module1/module-b/terragrunt.hcl
@@ -9,4 +9,5 @@ terraform {
 inputs = {
   module_name = "module-b"
   resource_id = "resource-002"
+  unit_secret = "secret-terragrunt-module1-module-b"
 }

--- a/terragrunt-module1/module-c/terragrunt.hcl
+++ b/terragrunt-module1/module-c/terragrunt.hcl
@@ -10,4 +10,5 @@ include {
 inputs = {
   module_name = "module-c"
   resource_id = "resource-003"
+  unit_secret = "secret-terragrunt-module1-module-c"
 }

--- a/terragrunt-module1/module-c/terragrunt.hcl
+++ b/terragrunt-module1/module-c/terragrunt.hcl
@@ -2,7 +2,7 @@ terraform {
   source = "../../base/main.tf"
 }
 
-include {
+include "root" {
   path = find_in_parent_folders("../base/backend.hcl")
 }
 

--- a/terragrunt-module1/module-d/terragrunt.hcl
+++ b/terragrunt-module1/module-d/terragrunt.hcl
@@ -11,4 +11,5 @@ include {
 inputs = {
   module_name = "module-d"
   resource_id = "resource-003"
+  unit_secret = "secret-terragrunt-module1-module-d"
 }

--- a/terragrunt-module1/module-d/terragrunt.hcl
+++ b/terragrunt-module1/module-d/terragrunt.hcl
@@ -2,7 +2,7 @@ terraform {
   source = "../../base/main.tf"
 }
 
-include {
+include "root" {
   path = find_in_parent_folders("../base/backend.hcl")
 }
 

--- a/terragrunt-module1/module-f/terragrunt.hcl
+++ b/terragrunt-module1/module-f/terragrunt.hcl
@@ -10,4 +10,5 @@ include {
 inputs = {
   module_name = "module-f"
   resource_id = "resource-003"
+  unit_secret = "secret-terragrunt-module1-module-f"
 }

--- a/terragrunt-module1/module-f/terragrunt.hcl
+++ b/terragrunt-module1/module-f/terragrunt.hcl
@@ -2,7 +2,7 @@ terraform {
   source = "../../base/main.tf"
 }
 
-include {
+include "root" {
   path = find_in_parent_folders("../base/backend.hcl")
 }
 


### PR DESCRIPTION
Makes this repo usable for the SCALRCORE-37162 checklist scenario:

> Terragrunt run with several units, each with sensitive values → per-unit sanitized and visual blobs produced; per-unit Resource changes view renders masked values.

## Why

The multi-unit `run-all` structure was already right — 10 units across two directories, all sharing `base/main.tf`. What was missing is that **nothing was sensitive in a way the sanitizer could act on**.

`var.sensitive_var_module-w` is declared `sensitive = true` but never referenced by any resource or output. So it shows up only in `variables[].value` and `configuration.root_module.variables[].default`. No resource attribute and no output carried a mark, which means `resource_changes` had nothing masked — and that is exactly what the per-unit Resource changes view renders. The scenario would have passed while proving almost nothing.

Also worth noting: `random_string.example` does not help here. Unlike `random_password.result`, `random_string.result` is not schema-sensitive, so it produces no `after_sensitive` marks.

## What this adds

To `base/main.tf`:

- `var.unit_secret` — sensitive, set per unit
- `terraform_data.secrets` — sensitive values at a top-level key and under a nested object path, with plain siblings (`public`, `nested.plain`) that must stay readable, so over-masking is caught too
- `output "sensitive_output"`

Each unit's `terragrunt.hcl` now passes its own `unit_secret`, so masked values differ between units and per-unit output can be told apart.

## Why `terraform_data` and not `random_password`

Values have to be **known at plan time** to appear as masked. Computed attributes such as `random_password.result` are null in the plan, so the sanitizer has nothing to mask and the view shows nothing. `terraform_data` with `sensitive()` keeps the values known.

This requires Terraform >= 1.4. If the workspace pins something older, this needs reworking.

## Verified

`terraform validate` passes, and a plan for one unit produces:

```
MARKS terraform_data.secrets {"input": {"nested": {"deep": {"token": true}}, "secret": true}, "output": {}}
output_changes sensitive: {'sensitive_output': True, ...}
cfg vars sensitive: {'unit_secret': True, 'sensitive_var_module-w': True}
```

Only checked against a local `terraform plan` — not yet run through Scalr.

## Not changed

`module-b` includes `find_in_parent_folders("base/backend.hcl")` while every other unit uses `"../base/backend.hcl"`. Both appear to resolve to the same file, so this is cosmetic and left alone.